### PR TITLE
chat-spaceのDB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 |groupname|integer|null: false, foreign_key: true|
-|member|integer|null: false. oreign_key: true|
 
 ### groups association
 - has_many :users, through: :groups_users
@@ -34,14 +33,14 @@
 
 ### message associaton
 - belongs_to :user
-- has_many :group
+- belongs_to :group
 
 ## groups_usersテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### groups_users association
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ### user association
 - has_many :group, through: :groups_users
 - has_many :groups_user
+- belongs_to :message
 
 
 ## groupテーブル
@@ -18,13 +19,25 @@
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
-|groupname|integer|ull: false, foreign_key: true|
-|member|string|nll: false. oreign_key: true|
+|groupname|integer|null: false, foreign_key: true|
+|member|integer|null: false. oreign_key: true|
 
 ### groups association
 - has_many :user, through: :groups_users
 - has_many :groups_users
+- belongs_to :message
 
+## messageテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|integer|null: false, foreign_key: true|
+|image|string|null: false. oreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### message associaton
+- has_many :user
+- has_many :group
 
 ## groups_usersテーブル
 
@@ -36,7 +49,7 @@
 ### groups_users association
 - belongs_to :group
 - belongs_to :user
-
+- belongs_to :message
 
 
 This README would normally document whatever steps are necessary to get the

--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
 # README
-## userテーブル
+## usersテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|id|integer|null: false, |
-|nickname|integer|null: false, |
-|email|integer|null: false, |
-|possword|integer|null: false, |
+|name|string|null: false, index: ture|
 
 ### user association
-- has_many :group, through: :groups_users
-- has_many :groups_user
-- belongs_to :message
+- has_many :groups, through: :groups_users
+- has_many :groups_users
+- has_many :messages
 
 
-## groupテーブル
+## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
@@ -23,20 +20,20 @@
 |member|integer|null: false. oreign_key: true|
 
 ### groups association
-- has_many :user, through: :groups_users
+- has_many :users, through: :groups_users
 - has_many :groups_users
-- belongs_to :message
+- has_many :messages
 
-## messageテーブル
+## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|integer|null: false, foreign_key: true|
-|image|string|null: false. oreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|content|text||
+|image|string||
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### message associaton
-- has_many :user
+- belongs_to :user
 - has_many :group
 
 ## groups_usersテーブル
@@ -49,28 +46,5 @@
 ### groups_users association
 - belongs_to :group
 - belongs_to :user
-- belongs_to :message
 
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,43 @@
 # README
+## userテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|id|integer|null: false, |
+|nickname|integer|null: false, |
+|email|integer|null: false, |
+|possword|integer|null: false, |
+
+### user association
+- has_many :group, through: :groups_users
+- has_many :groups_user
+
+
+## groupテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+|groupname|integer|ull: false, foreign_key: true|
+|member|string|nll: false. oreign_key: true|
+
+### groups association
+- has_many :user, through: :groups_users
+- has_many :groups_users
+
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### groups_users association
+- belongs_to :group
+- belongs_to :user
+
+
 
 This README would normally document whatever steps are necessary to get the
 application up and running.


### PR DESCRIPTION
#what
READMEに必要だと思うエンティティを洗い出し、書き込みを行いました。

#why
chat-spaceのユーザー登録、グループ登録、メッセージ登録を行う際に保存をするためのデータベースが必要なため。はじめにREADMEに必要なテーブルの設定と、アソシエーションの設定を行った。